### PR TITLE
MULTIARCH-5995: add ppc64le support to the build

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -32,6 +32,11 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
 
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+        with:
+          platforms: linux/amd64,linux/arm64,linux/ppc64le
+
       - name: Log in to the Container registry
         if: github.event_name != 'pull_request'
         uses: docker/login-action@v3
@@ -68,4 +73,4 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
-          platforms: linux/amd64,linux/arm64
+          platforms: linux/amd64,linux/arm64,linux/ppc64le

--- a/RELEASE.md
+++ b/RELEASE.md
@@ -55,7 +55,7 @@ gh release create v1.2.3 \
 ### 3. Automated Publishing
 
 Once the release is created, GitHub Actions will automatically:
-1. Build multi-platform Docker images (linux/amd64, linux/arm64)
+1. Build multi-platform Docker images (linux/amd64, linux/arm64, linux/ppc64le)
 2. Push to GitHub Container Registry with tags:
    - `ghcr.io/kuadrant/kuadrant-mcp-server:1.2.3` (exact version)
    - `ghcr.io/kuadrant/kuadrant-mcp-server:1.2` (minor version)
@@ -123,9 +123,9 @@ Check the [Actions tab](https://github.com/kuadrant/kuadrant-mcp-server/actions)
 - Never force-push or delete published tags
 
 ### Multi-platform Issues
-The workflow builds for both `linux/amd64` and `linux/arm64`. If one fails:
+The workflow builds for `linux/amd64`, `linux/arm64` and `linux/ppc64le`. If one fails:
 1. Check architecture-specific dependencies
-2. Test locally with: `docker buildx build --platform linux/arm64 .`
+2. Test locally with: `docker buildx build --platform linux/arm64 .` or  `docker buildx build --platform linux/ppc64le .`
 
 ## Pre-release Checklist
 


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Docker image builds now support multi-platform architecture for `linux/ppc64le`, significantly expanding deployment compatibility across diverse processor architectures.

* **Documentation**
  * Enhanced troubleshooting guidance for multi-platform Docker builds with expanded failure-checking procedures and practical examples for the newly supported `linux/ppc64le` architecture.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/Kuadrant/kuadrant-mcp-server/pull/6)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->